### PR TITLE
Add paths option, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,51 @@
 
 Nextflow plugin for interacting with [Quilt](https://quiltdata.com/) packages.
 
-`nf-quilt` currently allows you to publish the outputs of a workflow run as a Quilt package. WHen you launch a pipeline with the `nf-quilt` plugin, it will collect every output file that is published to S3 and publish a Quilt package upon workflow completion.
+`nf-quilt` currently allows you to publish the outputs of a workflow run as a Quilt package. WHen you launch a pipeline with the `nf-quilt` plugin, it will publish a Quilt package upon workflow completion that contains output files published to S3.
 
-## Requirements
+## Getting Started
 
-- Nextflow 22.04 or later
-- Python 3.7 or later
-- The [quilt-api](https://github.com/seqeralabs/quilt-api) package
+To use the `nf-quilt` plugin, you need Nextflow 22.04 (or later) and Python 3.7 (or later).
 
-## Usage
-
-To enable the plugin, add the following snippet to your `nextflow.config`:
+Install the [quilt-api](https://github.com/seqeralabs/quilt-api) package:
+```bash
+pip3 install git+ssh://git@github.com/seqeralabs/quilt-api.git
 ```
+
+Add the following snippet to your `nextflow.config` to enable the plugin:
+```groovy
 plugins {
     id 'nf-quilt'
 }
 ```
 
-## Configuration
+Configure the plugin with the `quilt` config scope in your `nextflow.config`. At a minimum, you should specify the package name and registry. You can also specify a list of paths to include in the Quilt package; by default, the plugin will include all output files that were published to S3.
 
-The plugin adds a new `quilt` config scope which supports the following options:
+Here's an example based on `nf-core/rnaseq`:
+```groovy
+quilt {
+  packageName = 'genomes/yeast'
+  registry = 's3://seqera-quilt'
+  message = 'My commit message'
+  meta = [pipeline: 'nf-core/rnaseq']
+  force = false
+
+  paths = [
+    'multiqc_report.html',
+    '**/star_salmon/**/deseq2.plots.pdf',
+    '**/star_salmon/salmon.merged.gene_counts.tsv',
+    '**/star_salmon/salmon.merged.gene_tpm.tsv',
+    '**/star_salmon/salmon.merged.transcript_counts.tsv',
+    '**/star_salmon/salmon.merged.transcript_tpm.tsv'
+  ]
+}
+```
+
+Finally, run your Nextflow pipeline with your config file. You do not need to modify your pipeline script in order to use the `nf-quilt` plugin. As long as your pipeline publishes the desired output files to S3, the plugin will automatically publish a Quilt package based on your configuration settings.
+
+## Reference
+
+The plugin exposes a new `quilt` config scope which supports the following options:
 
 | Config option 	    | Description 	            |
 |---	                |---	                      |
@@ -29,18 +54,8 @@ The plugin adds a new `quilt` config scope which supports the following options:
 | `quilt.registry`    | Registry where to create the new package
 | `quilt.message`     | The commit message for the new package
 | `quilt.meta`        | Package-level metadata in the form of key-value pairs
-| `quilt.force`       | Skip the parent top hash check and create a new revision even if your local state is behind the remote registry.
-
-For example:
-```
-quilt {
-  packageName = 'genomes/ecoli'
-  registry = 's3://seqera-quilt'
-  message = 'My commit message'
-  meta = [key: 'value']
-  force = false
-}
-```
+| `quilt.force`       | Skip the parent top hash check and create a new revision even if your local state is behind the remote registry
+| `quilt.paths`       | List of published files (can be path or glob) to include in the package
 
 ## Development
 


### PR DESCRIPTION
This PR adds `paths` option to the quilt config. If no paths are given, the plugin will include all published files in the quilt package. Otherwise, the user can provide a list of paths / globs and the plugin will only include files that are matched. Similar to the `reports` section of `tower.yml`.

Also expands the README with a more thorough "getting started" section.

Closes #1 